### PR TITLE
Smarter file walking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ A command-line tool to automatically update GitHub Actions workflow files, repla
 update-action-pins <file-or-dir>
 ```
 
-- `<file-or-dir>`: Path to a workflow YAML file or a directory containing workflow files.
+- `<file-or-dir>`: Path to a workflow YAML file or a directory containing workflow files. Defaults to ".github/workflows"
 
 Example:
 ```sh
-update-action-pins .github/workflows
+update-action-pins
+
+update-action-pins .github/workflows/test.yml
 ```
 
 ## Requirements


### PR DESCRIPTION
- Only grab yaml files from the referenced directory
- Only scan and regex replace in the file if its a github action file Also:
Add .github/workflows as a default folder to scan if no argument provided